### PR TITLE
Bundle nlohmann json header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(
     ${AVUTIL_INCLUDE_DIRS}
 )
 
-include_directories(${CMAKE_SOURCE_DIR}/third_party)
+include_directories(${CMAKE_SOURCE_DIR}/third_party/nlohmann)
 
 set(SOURCES
     src/main.cpp


### PR DESCRIPTION
## Summary
- add the bundled nlohmann json header
- include `third_party/nlohmann` directly for builds

## Testing
- `cmake ..` *(fails: Package 'srt', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531fe372b083259203af1d43ecd5c8