### PR TITLE
Detect librist via pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,17 @@ pkg_check_modules(SRT REQUIRED srt)
 pkg_check_modules(AVFORMAT REQUIRED libavformat)
 pkg_check_modules(AVCODEC REQUIRED libavcodec)
 pkg_check_modules(AVUTIL REQUIRED libavutil)
+pkg_check_modules(RIST REQUIRED librist)
 
 include_directories(
     ${SRT_INCLUDE_DIRS}
     ${AVFORMAT_INCLUDE_DIRS}
     ${AVCODEC_INCLUDE_DIRS}
     ${AVUTIL_INCLUDE_DIRS}
+    ${RIST_INCLUDE_DIRS}
 )
 
-include_directories(${CMAKE_SOURCE_DIR}/third_party/nlohmann)
+include_directories(${CMAKE_SOURCE_DIR}/third_party)
 
 set(SOURCES
     src/main.cpp
@@ -27,6 +29,7 @@ set(SOURCES
     src/rtsp_input.cpp
     src/feedback.cpp
     src/network_utils.cpp
+    src/rist_output.cpp
 )
 
 add_executable(srt_to_rist_gateway ${SOURCES})
@@ -36,6 +39,7 @@ target_link_libraries(srt_to_rist_gateway
     ${AVFORMAT_LIBRARIES}
     ${AVCODEC_LIBRARIES}
     ${AVUTIL_LIBRARIES}
+    ${RIST_LIBRARIES}
     pthread
     spdlog::spdlog
 )

--- a/src/srt_input.cpp
+++ b/src/srt_input.cpp
@@ -1,6 +1,7 @@
 #include "srt_input.h"
 #include <iostream>
 #include <vector>
+#include <algorithm>
 #include <thread>
 #include <chrono>
 


### PR DESCRIPTION
## Summary
- find librist with `pkg_check_modules`
- link against librist and expose its include directories
- fix missing `<algorithm>` include in `srt_input.cpp`

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: incomplete types from librist headers)*

------
https://chatgpt.com/codex/tasks/task_e_685329c9716883259d0a08b48246c670