### PR TITLE
Add configurable feedback destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,15 @@ These provide the SRT, RIST and FFmpeg libraries used by the gateway.
 
 The resulting `.ipk` file will be found in `bin/packages/*/`. Install it on your OpenWRT device with `opkg install <package>.ipk`.
 
+## Configuration
+
+Settings are loaded from `config.json`. Key options include:
+
+- `mode` - `srt` or `rtsp` input mode
+- `srt_mode` - SRT mode (`caller`, `listener`, or `multi`)
+- `rist_dst`/`rist_port` - destination for the RIST stream
+- `feedback_ip`/`feedback_port` - address for feedback messages to the encoder
+- `min_bitrate`/`max_bitrate` - bitrate limits used when generating feedback
+
+Refer to the bundled `config.json` for a full example.
+

--- a/config.json
+++ b/config.json
@@ -4,6 +4,8 @@
   "listen_port": 1234,
   "rist_dst": "192.168.1.200",
   "rist_port": 8000,
+  "feedback_ip": "192.168.1.50",
+  "feedback_port": 5005,
   "min_bitrate": 1000,
   "max_bitrate": 5000
 }

--- a/src/config.h
+++ b/src/config.h
@@ -38,6 +38,10 @@ struct Config {
     // RIST settings
     std::string rist_dst;
     int rist_port;
+
+    // Feedback settings
+    std::string feedback_ip = "192.168.1.50";
+    int feedback_port = 5005;
     
     // Bitrate settings
     int min_bitrate;

--- a/src/feedback.h
+++ b/src/feedback.h
@@ -7,7 +7,8 @@
 
 class Feedback {
 public:
-    Feedback(uint32_t min_bitrate, uint32_t max_bitrate);
+    Feedback(uint32_t min_bitrate, uint32_t max_bitrate,
+             const std::string& ip, int port);
     ~Feedback();
     
     // Process network stats and send feedback
@@ -31,6 +32,8 @@ private:
     
     uint32_t m_min_bitrate;
     uint32_t m_max_bitrate;
+    std::string m_ip;
+    int m_port;
     int m_socket_fd = -1;
     std::mutex m_mutex;
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,10 @@ Config parse_config(const std::string& config_path) {
         
         config.min_bitrate = j.at("min_bitrate");
         config.max_bitrate = j.at("max_bitrate");
+
+        // Parse feedback settings
+        config.feedback_ip = j.value("feedback_ip", config.feedback_ip);
+        config.feedback_port = j.value("feedback_port", config.feedback_port);
         
     } catch (json::exception& e) {
         throw std::runtime_error("JSON parsing error: " + std::string(e.what()));
@@ -105,7 +109,9 @@ int main(int argc, char* argv[]) {
         Config config = parse_config(argv[1]);
         
         // Setup feedback handler
-        auto feedback = std::make_shared<Feedback>(config.min_bitrate, config.max_bitrate);
+        auto feedback = std::make_shared<Feedback>(
+            config.min_bitrate, config.max_bitrate,
+            config.feedback_ip, config.feedback_port);
         
         // Setup input and output based on config
         std::unique_ptr<InputBase> input;


### PR DESCRIPTION
## Summary
- add feedback IP and port to `Config`
- parse feedback fields from `config.json`
- pass IP and port into `Feedback`
- document new options in README
- adjust sample configuration

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: no matching function for call to `find` in srt_input.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_685329cb78d48325b54a3df06a4e7d32