### PR TITLE
Improve config error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ Settings are loaded from `config.json`. Key options include:
 - `srt_mode` - SRT mode (`caller`, `listener`, or `multi`)
 - `rist_dst`/`rist_port` - destination for the RIST stream
 - `feedback_ip`/`feedback_port` - address for feedback messages to the encoder
+  (optional, default `192.168.1.50:5005`)
 - `min_bitrate`/`max_bitrate` - bitrate limits used when generating feedback
+- `filter_to_wan` - when using multi route mode, limit automatic interface
+  selection to WAN interfaces (default `true`)
+
+If any of the required options are missing from the configuration file, the
+gateway will print a clear error message indicating which key was expected.
 
 Refer to the bundled `config.json` for a full example.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,32 +36,39 @@ Config parse_config(const std::string& config_path) {
     try {
         json j;
         config_file >> j;
-        
+
+        auto require = [&](const json &obj, const std::string &key) -> const json & {
+            if (!obj.contains(key)) {
+                throw std::runtime_error("Missing required key '" + key + "'");
+            }
+            return obj.at(key);
+        };
+
         // Parse mode
-        std::string mode = j.at("mode");
+        std::string mode = require(j, "mode").get<std::string>();
         if (mode == "srt") {
             config.mode = InputMode::SRT;
-            
+
             // Parse SRT mode
-            std::string srt_mode = j.at("srt_mode");
+            std::string srt_mode = require(j, "srt_mode").get<std::string>();
             if (srt_mode == "caller") {
                 config.srt_mode = SRTMode::CALLER;
-                config.input_url = j.at("input_url");
+                config.input_url = require(j, "input_url").get<std::string>();
             } else if (srt_mode == "listener") {
                 config.srt_mode = SRTMode::LISTENER;
-                config.listen_port = j.at("listen_port");
+                config.listen_port = require(j, "listen_port").get<int>();
             } else if (srt_mode == "multi") {
                 config.srt_mode = SRTMode::MULTI;
-                config.listen_port = j.at("listen_port");
+                config.listen_port = require(j, "listen_port").get<int>();
                 config.filter_to_wan = j.value("filter_to_wan", true);
-                
+
                 // Parse multi-route configuration
-                auto routes = j.at("multi_route");
+                auto routes = require(j, "multi_route");
                 for (const auto& route : routes) {
                     MultiRouteConfig mrc;
-                    mrc.interface_ip = route.at("interface_ip");
-                    mrc.rist_dst = route.at("rist_dst");
-                    mrc.rist_port = route.at("rist_port");
+                    mrc.interface_ip = require(route, "interface_ip").get<std::string>();
+                    mrc.rist_dst = require(route, "rist_dst").get<std::string>();
+                    mrc.rist_port = require(route, "rist_port").get<int>();
                     config.multi_routes.push_back(mrc);
                 }
             } else {
@@ -69,19 +76,19 @@ Config parse_config(const std::string& config_path) {
             }
         } else if (mode == "rtsp") {
             config.mode = InputMode::RTSP;
-            config.input_url = j.at("input_url");
+            config.input_url = require(j, "input_url").get<std::string>();
         } else {
             throw std::runtime_error("Invalid mode: " + mode);
         }
         
         // Parse common parameters
         if (config.srt_mode != SRTMode::MULTI) {
-            config.rist_dst = j.at("rist_dst");
-            config.rist_port = j.at("rist_port");
+            config.rist_dst = require(j, "rist_dst").get<std::string>();
+            config.rist_port = require(j, "rist_port").get<int>();
         }
-        
-        config.min_bitrate = j.at("min_bitrate");
-        config.max_bitrate = j.at("max_bitrate");
+
+        config.min_bitrate = require(j, "min_bitrate").get<int>();
+        config.max_bitrate = require(j, "max_bitrate").get<int>();
 
         // Parse feedback settings
         config.feedback_ip = j.value("feedback_ip", config.feedback_ip);


### PR DESCRIPTION
## Summary
- clarify README config options
- validate config values with helper and defaults

## Testing
- `cmake -S . -B build` *(fails: Findspdlog.cmake not found)*
- `cmake --build build` *(fails: no Makefile)*
- `g++ -std=c++17 -Ithird_party -I./src -c src/main.cpp -o /tmp/main.o` *(fails: srt/srt.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68532ea0d3608325896afb2dd2c196b2