### PR TITLE
Update gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
 node_modules
 .env
+
+# Build artifacts
+build/
+*.ipk
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+
+# OpenWRT build directories
+bin/
+build_dir/
+staging_dir/
+tmp/


### PR DESCRIPTION
## Summary
- ignore OpenWRT/CMake build artifacts like `build/`, `*.ipk`, and various CMake files

## Testing
- `make -n` *(fails: No rule to make target `/cmake.mk`)*
- `cmake -S . -B build` *(fails: Could not find package `spdlog`)*

------
https://chatgpt.com/codex/tasks/task_e_68532ea207548325b1103e8aec16ab7f