### PR TITLE
Fix RTSP config parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ include_directories(${CMAKE_SOURCE_DIR}/third_party)
 
 set(SOURCES
     src/main.cpp
+    src/config_parser.cpp
     src/srt_input.cpp
     src/rtsp_input.cpp
     src/feedback.cpp

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -1,0 +1,85 @@
+#include "config_parser.h"
+
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <iostream>
+
+using json = nlohmann::json;
+
+Config parse_config(const std::string& config_path) {
+    Config config;
+
+    std::ifstream config_file(config_path);
+    if (!config_file.is_open()) {
+        throw std::runtime_error("Failed to open config file: " + config_path);
+    }
+
+    try {
+        json j;
+        config_file >> j;
+
+        auto require = [&](const json &obj, const std::string &key) -> const json & {
+            if (!obj.contains(key)) {
+                throw std::runtime_error("Missing required key '" + key + "'");
+            }
+            return obj.at(key);
+        };
+
+        // Parse mode
+        std::string mode = require(j, "mode").get<std::string>();
+        if (mode == "srt") {
+            config.mode = InputMode::SRT;
+
+            // Parse SRT mode
+            std::string srt_mode = require(j, "srt_mode").get<std::string>();
+            if (srt_mode == "caller") {
+                config.srt_mode = SRTMode::CALLER;
+                config.input_url = require(j, "input_url").get<std::string>();
+            } else if (srt_mode == "listener") {
+                config.srt_mode = SRTMode::LISTENER;
+                config.listen_port = require(j, "listen_port").get<int>();
+            } else if (srt_mode == "multi") {
+                config.srt_mode = SRTMode::MULTI;
+                config.listen_port = require(j, "listen_port").get<int>();
+                config.filter_to_wan = j.value("filter_to_wan", true);
+
+                // Parse multi-route configuration
+                auto routes = require(j, "multi_route");
+                for (const auto& route : routes) {
+                    MultiRouteConfig mrc;
+                    mrc.interface_ip = require(route, "interface_ip").get<std::string>();
+                    mrc.rist_dst = require(route, "rist_dst").get<std::string>();
+                    mrc.rist_port = require(route, "rist_port").get<int>();
+                    config.multi_routes.push_back(mrc);
+                }
+            } else {
+                throw std::runtime_error("Invalid SRT mode: " + srt_mode);
+            }
+        } else if (mode == "rtsp") {
+            config.mode = InputMode::RTSP;
+            config.input_url = require(j, "input_url").get<std::string>();
+        } else {
+            throw std::runtime_error("Invalid mode: " + mode);
+        }
+
+        // Parse common parameters
+        if (config.mode != InputMode::SRT || config.srt_mode != SRTMode::MULTI) {
+            config.rist_dst = require(j, "rist_dst").get<std::string>();
+            config.rist_port = require(j, "rist_port").get<int>();
+        }
+
+        config.min_bitrate = require(j, "min_bitrate").get<int>();
+        config.max_bitrate = require(j, "max_bitrate").get<int>();
+
+        // Parse feedback settings
+        config.feedback_ip = j.value("feedback_ip", config.feedback_ip);
+        config.feedback_port = j.value("feedback_port", config.feedback_port);
+
+    } catch (json::exception& e) {
+        throw std::runtime_error("JSON parsing error: " + std::string(e.what()));
+    }
+
+    return config;
+}
+

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -1,0 +1,9 @@
+#ifndef CONFIG_PARSER_H
+#define CONFIG_PARSER_H
+
+#include <string>
+#include "config.h"
+
+Config parse_config(const std::string& config_path);
+
+#endif // CONFIG_PARSER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "rist_output.h"
 #include "feedback.h"
 #include "network_utils.h"
+#include "config_parser.h"
 
 using json = nlohmann::json;
 
@@ -24,82 +25,6 @@ void signal_handler(int signal) {
     running = 0;
 }
 
-// Parse config file and return Config object
-Config parse_config(const std::string& config_path) {
-    Config config;
-    
-    std::ifstream config_file(config_path);
-    if (!config_file.is_open()) {
-        throw std::runtime_error("Failed to open config file: " + config_path);
-    }
-    
-    try {
-        json j;
-        config_file >> j;
-
-        auto require = [&](const json &obj, const std::string &key) -> const json & {
-            if (!obj.contains(key)) {
-                throw std::runtime_error("Missing required key '" + key + "'");
-            }
-            return obj.at(key);
-        };
-
-        // Parse mode
-        std::string mode = require(j, "mode").get<std::string>();
-        if (mode == "srt") {
-            config.mode = InputMode::SRT;
-
-            // Parse SRT mode
-            std::string srt_mode = require(j, "srt_mode").get<std::string>();
-            if (srt_mode == "caller") {
-                config.srt_mode = SRTMode::CALLER;
-                config.input_url = require(j, "input_url").get<std::string>();
-            } else if (srt_mode == "listener") {
-                config.srt_mode = SRTMode::LISTENER;
-                config.listen_port = require(j, "listen_port").get<int>();
-            } else if (srt_mode == "multi") {
-                config.srt_mode = SRTMode::MULTI;
-                config.listen_port = require(j, "listen_port").get<int>();
-                config.filter_to_wan = j.value("filter_to_wan", true);
-
-                // Parse multi-route configuration
-                auto routes = require(j, "multi_route");
-                for (const auto& route : routes) {
-                    MultiRouteConfig mrc;
-                    mrc.interface_ip = require(route, "interface_ip").get<std::string>();
-                    mrc.rist_dst = require(route, "rist_dst").get<std::string>();
-                    mrc.rist_port = require(route, "rist_port").get<int>();
-                    config.multi_routes.push_back(mrc);
-                }
-            } else {
-                throw std::runtime_error("Invalid SRT mode: " + srt_mode);
-            }
-        } else if (mode == "rtsp") {
-            config.mode = InputMode::RTSP;
-            config.input_url = require(j, "input_url").get<std::string>();
-        } else {
-            throw std::runtime_error("Invalid mode: " + mode);
-        }
-        
-        // Parse common parameters
-        if (config.srt_mode != SRTMode::MULTI) {
-            config.rist_dst = require(j, "rist_dst").get<std::string>();
-            config.rist_port = require(j, "rist_port").get<int>();
-        }
-
-        config.min_bitrate = require(j, "min_bitrate").get<int>();
-        config.max_bitrate = require(j, "max_bitrate").get<int>();
-
-        // Parse feedback settings
-        config.feedback_ip = j.value("feedback_ip", config.feedback_ip);
-        config.feedback_port = j.value("feedback_port", config.feedback_port);
-        
-    } catch (json::exception& e) {
-        throw std::runtime_error("JSON parsing error: " + std::string(e.what()));
-    }
-    
-    return config;
-}
 
 int main(int argc, char* argv[]) {
     if (argc < 2) {

--- a/tests/parse_config_test.cpp
+++ b/tests/parse_config_test.cpp
@@ -1,0 +1,17 @@
+#include "config_parser.h"
+#include <iostream>
+
+int main() {
+    try {
+        Config cfg = parse_config("tests/rtsp_config.json");
+        if (cfg.mode != InputMode::RTSP) {
+            std::cerr << "Wrong mode" << std::endl;
+            return 1;
+        }
+        std::cout << "Parsed successfully" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}

--- a/tests/rtsp_config.json
+++ b/tests/rtsp_config.json
@@ -1,0 +1,8 @@
+{
+  "mode": "rtsp",
+  "input_url": "rtsp://example.com/stream",
+  "rist_dst": "192.168.1.200",
+  "rist_port": 8000,
+  "min_bitrate": 1000,
+  "max_bitrate": 2000
+}


### PR DESCRIPTION
## Summary
- refactor `parse_config` into new `config_parser` module
- avoid reading uninitialized `srt_mode` when parsing RTSP configs
- add regression test parsing an RTSP config under valgrind

## Testing
- `g++ -std=c++17 tests/parse_config_test.cpp src/config_parser.cpp -Ithird_party -Isrc -o tests/parse_config_test`
- `valgrind ./tests/parse_config_test`

------
https://chatgpt.com/codex/tasks/task_e_68533344b3b88325aa8f0c32cb43c4f5