### PR TITLE
Fix package maintainer email

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ define Package/$(PKG_NAME)
   CATEGORY:=Network
   TITLE:=SRT to RIST gateway
   DEPENDS:=+libstdcpp +librist +srt +ffmpeg +libopenssl +libpthread
-  URL:=https://github.com/yourusername/srt-to-rist-gateway
-  MAINTAINER:=Your Name <your.email@example.com>
+  URL:=https://github.com/bofika/SRTtoRIST
+  MAINTAINER:=bofika <gergely.both@streamterminal.com>
 endef
 
 define Package/$(PKG_NAME)/description


### PR DESCRIPTION
## Summary
- update maintainer contact in `Makefile`

## Testing
- `cmake ..` *(fails: missing `spdlog` config)*
- `make -j$(nproc)` *(fails: no Makefile because cmake failed)*

------
https://chatgpt.com/codex/tasks/task_e_6853335c84008325884ce71d3ed3f019