### PR TITLE
Update feed branches to v23.05.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,8 @@ jobs:
           mkdir -p openwrt-sdk/package/{libs,multimedia}
           
           # Clone repositories in parallel
-          git clone --depth=1 --branch openwrt-23.05 https://github.com/openwrt/packages.git openwrt-packages &
-          git clone --depth=1 --branch openwrt-23.05 https://github.com/openwrt/openwrt.git openwrt-core &
+          git clone --depth=1 --branch v23.05.3 https://github.com/openwrt/packages.git openwrt-packages &
+          git clone --depth=1 --branch v23.05.3 https://github.com/openwrt/openwrt.git openwrt-core &
           git clone --depth=1 https://github.com/Haivision/srt.git openwrt-srt &
           git clone --depth=1 https://code.videolan.org/rist/librist.git openwrt-librist &
           git clone --depth=1 https://github.com/gabime/spdlog.git openwrt-spdlog &
@@ -95,10 +95,10 @@ jobs:
           rm -rf feeds tmp
           
           cat > feeds.conf <<EOF
-          src-git packages https://github.com/openwrt/packages.git;openwrt-23.05
-          src-git luci https://github.com/openwrt/luci.git;openwrt-23.05
-          src-git routing https://github.com/openwrt/routing.git;openwrt-23.05
-          src-git telephony https://github.com/openwrt/telephony.git;openwrt-23.05
+          src-git packages https://github.com/openwrt/packages.git;v23.05.3
+          src-git luci https://github.com/openwrt/luci.git;v23.05.3
+          src-git routing https://github.com/openwrt/routing.git;v23.05.3
+          src-git telephony https://github.com/openwrt/telephony.git;v23.05.3
           EOF
           
           ./scripts/feeds update -a


### PR DESCRIPTION
## Summary
- update checkout commands in workflow to use `v23.05.3`
- use `;v23.05.3` for each feed source in feeds.conf

## Testing
- `cmake ..` (fails: could not find spdlog)


------
https://chatgpt.com/codex/tasks/task_e_685343e79f508325a4e262cc2d25ca8d