### PR TITLE
Fix build package step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Build package
         run: |
           cd openwrt-sdk
-          make package/srt-to-rist-gateway/compile -j$(nproc) || {
+          make package/srt-to-rist-gateway/compile -j1 V=s || {
             echo "Build failed"
             find logs -type f -name '*.txt' -exec cat {} \;
             exit 1


### PR DESCRIPTION
## Summary
- set `-j1 V=s` when building package in workflow

## Testing
- `g++ -std=c++17 -I third_party -I src tests/parse_config_test.cpp src/config_parser.cpp -o parse_config_test && ./parse_config_test`

------
https://chatgpt.com/codex/tasks/task_e_685343e9f5e08325bb4641f8aa599b11