### PR TITLE
Fix OpenSSL devcrypto build error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,13 @@ jobs:
           cp -r openwrt-librist openwrt-sdk/package/libs/librist
           cp -r openwrt-spdlog openwrt-sdk/package/libs/spdlog
 
+      - name: Disable devcrypto engine in OpenSSL
+        run: |
+          sed -i '/^OPENSSL_OPTIONS:=/ s/$/ no-devcryptoeng/' \
+            openwrt-sdk/package/libs/libopenssl/Makefile
+          sed -i 's/enable-devcryptoeng/no-devcryptoeng/' \
+            openwrt-sdk/package/libs/libopenssl/Makefile
+
       - name: Update and install feeds
         run: |
           cd openwrt-sdk

--- a/README.md
+++ b/README.md
@@ -52,8 +52,13 @@ These provide the SRT, RIST and FFmpeg libraries used by the gateway.
    cp -r /path/to/srt-to-rist-gateway/* package/srt-to-rist-gateway/
    ```
 
-5. **Select the required packages** using `make menuconfig` (or edit `.config` directly). Enable the packages listed above together with `srt-to-rist-gateway`.
-6. **Build the package**:
+5. **Disable the devcrypto engine in OpenSSL** to avoid build failures:
+
+   Add `no-devcryptoeng` to the `OPENSSL_OPTIONS` (or `CONFIGURE_ARGS`) in
+   `package/libs/libopenssl/Makefile` within the SDK.
+
+6. **Select the required packages** using `make menuconfig` (or edit `.config` directly). Enable the packages listed above together with `srt-to-rist-gateway`.
+7. **Build the package**:
 
    ```sh
    make package/srt-to-rist-gateway/compile -j$(nproc)


### PR DESCRIPTION
## Summary
- document how to disable the devcrypto engine when building with the OpenWRT SDK
- patch workflow to automatically disable devcrypto engine during CI

## Testing
- `pytest -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6853582d99908325a8af8d3f3f8f5f17