### PR TITLE
Add third-party license for nlohmann json

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,9 @@ Refer to the bundled `config.json` for a full example.
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+## Third-party licenses
+
+This project bundles the [nlohmann/json](https://github.com/nlohmann/json)
+library, which is provided under the MIT License. See
+[third_party/nlohmann/LICENSE.MIT](third_party/nlohmann/LICENSE.MIT) for details.

--- a/third_party/nlohmann/LICENSE.MIT
+++ b/third_party/nlohmann/LICENSE.MIT
@@ -1,0 +1,21 @@
+MIT License 
+
+Copyright (c) 2013-2025 Niels Lohmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- add MIT license from the nlohmann/json project
- document third-party license in README

## Testing
- `g++ -std=c++17 -Isrc -Ithird_party tests/parse_config_test.cpp src/config_parser.cpp src/rtsp_input.cpp src/srt_input.cpp src/network_utils.cpp src/feedback.cpp src/rist_output.cpp src/main.cpp -o tests/test_executable` *(fails: librist/librist.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6853d76fd55c8325a33f8ccaee4e7170