### PR TITLE
Ensure clean OpenWRT builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,12 @@ jobs:
           
           make defconfig
 
+      - name: Clean OpenWRT build directories
+        run: |
+          rm -rf openwrt-sdk/build_dir
+          rm -rf openwrt-sdk/tmp
+          rm -rf openwrt-sdk/staging_dir
+
       - name: Build package
         run: |
           cd openwrt-sdk

--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ These provide the SRT, RIST and FFmpeg libraries used by the gateway.
    `package/libs/libopenssl/Makefile` within the SDK.
 
 6. **Select the required packages** using `make menuconfig` (or edit `.config` directly). Enable the packages listed above together with `srt-to-rist-gateway`.
-7. **Build the package**:
+7. **Clean previous build artifacts** (recommended when rebuilding):
+
+   ```sh
+   rm -rf build_dir tmp staging_dir
+   ```
+8. **Build the package**:
 
    ```sh
    make package/srt-to-rist-gateway/compile -j$(nproc)


### PR DESCRIPTION
## Summary
- clean the OpenWRT build directories before compiling in CI
- document cleaning step in README

## Testing
- `g++ tests/parse_config_test.cpp src/config_parser.cpp -std=c++17 -I third_party -I src -o parse_config_test && ./parse_config_test`

------
https://chatgpt.com/codex/tasks/task_e_685401fd054883259f367a901066aa7f